### PR TITLE
doc: fix preset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Or with a preset:
 
 ```js
 import { Deck, presets } from 'pasoor';
-const deck = new Deck(presets.shelem);
+const deck = Deck.create(presets.shelem);
 ```


### PR DESCRIPTION
Seems like the `Deck` constructor does not take any arguments so the preset example doesn't work. Should be using `Deck.create`, right?

``` javascript
const deck = new Deck(presets.shelem);
// => Deck { cards: [], deck: [], held: [], discard: [] }

const deck = Deck.create(presets.shelem);
// => Deck { cards: [ ... ], deck: [ ... ], held: [], discard: [] }
```
